### PR TITLE
Update dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:10-alpine
 RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
 WORKDIR /home/node/app
 COPY package*.json ./
-RUN npm config set registry http://registry.npmjs.org/
+RUN npm config set registry https://registry.npmjs.org/
 RUN npm install
 COPY . .
 COPY --chown=node:node . .


### PR DESCRIPTION
Update dockerfile to respond to the deprecation of tls 1.0, 1.1 warning in the npm registry.